### PR TITLE
feat(backup)!: overhaul backup script — age encryption, TOML config, restore mode

### DIFF
--- a/server-scripts/backup/python/overengineered-backup-script.py
+++ b/server-scripts/backup/python/overengineered-backup-script.py
@@ -720,7 +720,11 @@ def tar_is_gnu(tar_path: str) -> bool:
 # subprocess to finish on its own.
 
 _active_processes: set[subprocess.Popen[bytes] | subprocess.Popen[str]] = set()
-_process_lock = threading.Lock()
+# Reentrant on purpose: signal_handler() runs synchronously on the main thread
+# and may fire while that thread already holds this lock inside _track_process()
+# or _untrack_process(). A plain Lock would self-deadlock there; an RLock lets
+# the handler re-acquire it while still excluding the watchdog thread.
+_process_lock = threading.RLock()
 
 
 def _track_process(proc: subprocess.Popen[bytes] | subprocess.Popen[str]) -> None:
@@ -2229,11 +2233,19 @@ def rotate_items(
         patterns = [patterns]
 
     log.info(f"Rotating items in {dir_path} matching {patterns}...")
-    items = sorted(
-        {p for pattern in patterns for p in dir_path.glob(pattern) if p.is_file()},
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
+    candidates = {
+        p for pattern in patterns for p in dir_path.glob(pattern) if p.is_file()
+    }
+    # stat() best-effort: a file can vanish between the glob and this stat
+    # (concurrent cleanup, another run). Skip such files rather than let an
+    # uncaught FileNotFoundError abort an otherwise-successful backup run.
+    stated: list[tuple[float, Path]] = []
+    for candidate in candidates:
+        try:
+            stated.append((candidate.stat().st_mtime, candidate))
+        except OSError:
+            continue
+    items = [p for _, p in sorted(stated, key=lambda pair: pair[0], reverse=True)]
 
     removed: list[Path] = []
     for item in items[retention_count:]:
@@ -2381,19 +2393,23 @@ def create_backup(backup_file: Path) -> bool:
         tar_rc, compress_rc, encrypt_rc = result.returncodes
         tar_err, compress_err, encrypt_err = result.stderr
 
+        # Check downstream-first. When a later stage (e.g. age) fails and closes
+        # its stdin, the upstream stages die of SIGPIPE with negative exit codes.
+        # Reporting the most-downstream real failure first surfaces the true root
+        # cause instead of a misleading "Compression failed with exit code -13".
+        if encrypt_rc != 0:
+            raise BackupCreationError(
+                f"Encryption failed with exit code {encrypt_rc}: {encrypt_err}"
+            )
+        if compress_rc != 0:
+            raise BackupCreationError(
+                f"Compression failed with exit code {compress_rc}: {compress_err}"
+            )
         # tar exit code 1 means "some files changed while reading" - acceptable.
         if tar_rc > 1 or tar_rc < 0:
             raise BackupCreationError(f"Tar failed with exit code {tar_rc}: {tar_err}")
         if tar_rc == 1:
             log.warning("Some files changed during backup (non-critical)")
-        if compress_rc != 0:
-            raise BackupCreationError(
-                f"Compression failed with exit code {compress_rc}: {compress_err}"
-            )
-        if encrypt_rc != 0:
-            raise BackupCreationError(
-                f"Encryption failed with exit code {encrypt_rc}: {encrypt_err}"
-            )
 
         if not backup_file.exists():
             raise BackupCreationError("Final backup file was not created")

--- a/server-scripts/backup/python/overengineered-backup-script.py
+++ b/server-scripts/backup/python/overengineered-backup-script.py
@@ -2421,10 +2421,16 @@ def create_backup(backup_file: Path) -> bool:
         log.info(f"Backup created successfully: {format_bytes(final_size)}")
         return True
 
-    except (BackupError, OSError):
+    except (BackupError, OSError) as e:
         # Never leave a partial/corrupt archive behind.
         with contextlib.suppress(OSError):
             backup_file.unlink(missing_ok=True)
+        # OperationTimeout is a BackupError sibling, not a BackupCreationError;
+        # translate a create-time timeout so _run_backup() reports a clean
+        # stage-specific failure instead of an "unexpected critical error" dump
+        # (mirrors verify_backup, which re-raises timeouts as BackupVerificationError).
+        if isinstance(e, OperationTimeout):
+            raise BackupCreationError("Backup creation timed out") from e
         raise
 
 
@@ -2485,13 +2491,21 @@ def write_sha256_manifest(backup_file: Path) -> Path | None:
     if dry_run_mode:
         return None
 
-    h = hashlib.sha256()
-    with open(backup_file, "rb") as f:
-        while chunk := f.read(1024 * 1024):
-            h.update(chunk)
+    try:
+        h = hashlib.sha256()
+        with open(backup_file, "rb") as f:
+            while chunk := f.read(1024 * 1024):
+                h.update(chunk)
 
-    manifest = Path(str(backup_file) + ".sha256")
-    _ = manifest.write_text(f"{h.hexdigest()}  {backup_file.name}\n")
+        manifest = Path(str(backup_file) + ".sha256")
+        _ = manifest.write_text(f"{h.hexdigest()}  {backup_file.name}\n")
+    except OSError as e:
+        # A manifest is a convenience for checking remote copies; a write hiccup
+        # must not fail an already-verified backup or skip rotation/off-site sync.
+        log.warning(f"Could not write SHA-256 manifest for {backup_file.name}: {e}")
+        backup_state.add_warning(f"Could not write SHA-256 manifest: {e}")
+        return None
+
     log.info(f"SHA-256 manifest written: {manifest.name}")
 
     try:


### PR DESCRIPTION
## Note for reviewers

This is a **review-only PR**. The commits in this range (`eb8ecfc..fe024d3`) have already been merged to `main`; this PR exists to run the automated review bot against the full diff after the fact. The base branch `review-base/backup-script-overhaul` is a snapshot of `main` before the changes. **Do not merge** -- close this PR once the review is complete, then delete both branches.

## Summary

Complete overhaul of `server-scripts/backup/python/overengineered-backup-script.py` (5 commits): critical concurrency fixes, a streaming backup pipeline, age encryption, TOML-based configuration, a restore mode, a new test suite, and a zero-warning `basedpyright` pass.

## Changes

### Critical correctness fixes

- **Lock handling rewrite**: the lock file now stores the owning PID and staleness is determined by process liveness. Previously, a losing concurrent run would delete the winner's lock file on exit and then restart every Docker stack from its `finally` block -- mid-backup of the concurrent run. The lock is now acquired before the try/finally that owns Docker-restore duties, and cleanup only unlinks a lock this process created.
- **Guarded finalization**: service restarts, maintenance-window removal, and notifications only run once pre-flight has passed. Pre-flight failures raise `PreFlightError` instead of calling `sys.exit()`, and `sys.exit()` was moved out of the `finally` block so it can no longer mask in-flight exceptions.
- **Unreachable notification status**: the "Completed with Warnings" Discord status could never fire because the success flag already implied no errors. Status selection is now a pure, unit-tested function.
- **Signal responsiveness**: SIGTERM/SIGINT/SIGHUP now terminate the active subprocess (rclone, tar, verification) instead of waiting for it to finish on its own (previously up to two hours). The documented-but-unenforced `script_overall_timeout` is now enforced by a watchdog timer.
- **Pipeline stderr handling**: every pipeline stage writes stderr to a temp file instead of an unread `PIPE`, eliminating a deadlock when a failing stage produces more stderr than the pipe buffer holds.
- **Shebang/PEP 723 ordering**: the shebang is on line 1 (`#!/usr/bin/env -S uv run --script`) so direct execution resolves dependencies via `uv`.

### Efficiency

- **Streaming backup pipeline**: `tar -cf - ... | pigz | age` streams directly into the encrypted archive. The previous implementation wrote a full uncompressed temporary tar to disk first, doubling I/O and requiring free space equal to the uncompressed data size.
- **Concurrent Docker restarts**: non-Plex stacks start in parallel with a single settle delay, replacing a serial 30-second sleep per stack.
- **Single PrivateBin upload** per run instead of two or three duplicate uploads of the same log.

### Encryption: openssl to age

- Backups are now encrypted with `age` using an X25519 identity file (`age -e -i <identity>`), replacing unauthenticated `openssl enc -aes-256-cbc`. The `age` binary resolves through the existing Homebrew/Linuxbrew PATH fallback.
- Legacy `.enc` backups remain restorable through the restore subcommand until they rotate out.
- A `.sha256` manifest is written next to each backup so remote copies can be verified without downloading and decrypting.

### Configuration and CLI

- Settings moved to a TOML config file (`/etc/backup-script.toml`, overridable with `--config`); in-script constants are the defaults. Unknown sections/keys are hard errors. Secrets can be supplied via `BACKUP_UPTIME_KUMA_PASSWORD` and `BACKUP_DISCORD_WEBHOOK_URL` environment variables. `--print-default-config` emits a fully commented example.
- New CLI surface: `--verbose`, `--no-docker`, `--no-upload`, `--backup-only`, `--version`, and a `restore` subcommand (`restore <file> --list` / `--output-dir DIR [--force]`) supporting both `.age` and legacy `.enc` archives.
- `--dry-run` no longer requires root and reports source-directory status, resolved tool paths, rotation candidates, and integration configuration.

### Robustness

- Backups rotate only after successful verification, so a failed run never consumes existing good backups; rotation covers both `.age` and legacy `.enc` patterns plus orphaned manifests.
- Misconfigured integrations (missing Uptime Kuma credentials, absent PrivateBin CLI) disable themselves with a single warning instead of exhausting retry ladders at runtime.
- Maintenance-window state moved out of `/tmp` so it survives reboots; orphaned windows from crashed runs are cleaned up on the next run.
- Failure notifications include the stage in which the run failed.

### Testing

New `test_backup_script.py` (stdlib `unittest`, 33 tests): formatting helpers, rclone retry classification, status selection, TOML loading/validation/env overrides, rotation and manifest cleanup, PID-lock semantics (including the contention regression), corruption detection, and full age round-trips through create/verify/restore. Tool-dependent tests skip when `age` or GNU tar is unavailable.

### Type checking

`uvx basedpyright@latest` passes with 0 errors and 0 warnings (previously 3 errors, 67 warnings): typed `argparse.Namespace` subclass, a `Protocol` describing the untyped Uptime Kuma API surface, lowercase rename of the mutable `config` global, merged implicit string concatenations, and a typed function replacing an untyped lambda.

## Breaking changes

- Backups are encrypted with age (`*.tar.gz.age`); an identity must be generated before the first run: `age-keygen -o /root/.backup_age_key.txt && chmod 600 /root/.backup_age_key.txt` (keep an off-machine copy of the key).
- Configuration lives in a TOML file; in-script constant editing is no longer the supported workflow.
- GNU tar is required (resolved as `gtar` on macOS/Homebrew).

## Verification

- 33/33 unit tests pass, including an end-to-end create/verify/restore round-trip.
- CLI verified manually: `--version`, `--print-default-config` (round-trips through `tomllib` back to exact defaults), `--dry-run --verbose` as non-root, and `restore --list` / extraction with a byte-identical diff of restored files.
- `basedpyright`: 0 errors, 0 warnings, 0 notes.
