### PR TITLE
feat(backup)!: use post-quantum age keys and drop legacy openssl restore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ python server-scripts/backup/python/test_backup_script.py
 
 ### Python Backup Script
 - Creates encrypted backups via a streaming pipeline: tar -> pigz/gzip -> age (no temp tar on disk)
-- Encryption uses an age identity file (`/root/.backup_age_key.txt`); openssl is only needed to restore legacy `.enc` backups
+- Encryption uses an age identity file (`/root/.backup_age_key.txt`), generated post-quantum with `age-keygen -pq` (hybrid X25519 + ML-KEM-768, age >= 1.3.0); the pipeline encrypts to the identity's own recipient. Legacy openssl `.enc` restore support has been removed (decrypt those manually with `openssl`)
 - Configured via TOML file (`/etc/backup-script.toml`, override with `--config`); secrets via `BACKUP_UPTIME_KUMA_PASSWORD` / `BACKUP_DISCORD_WEBHOOK_URL` env vars; `--print-default-config` emits a commented example
 - CLI: `--dry-run` (root-free preflight preview), `--verbose`, `--no-docker`, `--no-upload`, `--backup-only`, and a `restore` subcommand (`restore <file> --list` / `--output-dir DIR`)
 - Requires GNU tar (resolved as `gtar` on macOS/brew); writes a `.sha256` manifest next to each backup

--- a/server-scripts/backup/python/overengineered-backup-script.py
+++ b/server-scripts/backup/python/overengineered-backup-script.py
@@ -325,6 +325,18 @@ _TOML_SCHEMA: dict[str, dict[str, str]] = {
 
 _PATH_LIST_ATTRS = {"backup_sources", "backup_exclusions"}
 
+# Config keys removed in past breaking changes, keyed by (section, key). Lets
+# _apply_toml give a targeted upgrade hint for a stale config instead of the
+# generic "unknown key" message (the removal only lives in git history otherwise).
+_REMOVED_TOML_KEYS: dict[tuple[str, str], str] = {
+    ("encryption", "legacy_password_file"): (
+        "the legacy openssl (.enc) encryption path was removed, so this key no "
+        "longer exists. Delete it from your config to run backups again; normal "
+        "age-based backups are unaffected. To read old .enc backups, decrypt them "
+        "manually with openssl."
+    ),
+}
+
 
 def _apply_toml(cfg: Config, data: dict[str, object], source: Path) -> None:
     """Apply a parsed TOML document onto a Config, validating every key."""
@@ -337,6 +349,9 @@ def _apply_toml(cfg: Config, data: dict[str, object], source: Path) -> None:
         for key, value in cast(dict[str, object], table).items():
             attr = section_schema.get(key)
             if attr is None:
+                hint = _REMOVED_TOML_KEYS.get((section, key))
+                if hint is not None:
+                    raise ConfigError(f"{source}: [{section}] {key} - {hint}")
                 raise ConfigError(f"{source}: unknown key '{key}' in [{section}]")
             default = cast(object, getattr(cfg, attr))
             if isinstance(default, Path):

--- a/server-scripts/backup/python/overengineered-backup-script.py
+++ b/server-scripts/backup/python/overengineered-backup-script.py
@@ -1784,11 +1784,12 @@ def _report_backup_sources() -> None:
         log.info(f"  excluded  {excl}{'' if excl.exists() else ' (not present)'}")
 
 
-def _identity_is_post_quantum(identity: Path) -> bool | None:
-    """Classify an age identity file: True if it holds a post-quantum secret
-    key (AGE-SECRET-KEY-PQ-...), False if it holds a classic X25519 key
-    (AGE-SECRET-KEY-1...), or None if the type can't be determined (e.g. a
-    plugin identity, or the file can't be read)."""
+def _scan_identity_key_types(identity: Path) -> tuple[bool, bool] | None:
+    """Scan an age identity file, returning (has_post_quantum, has_classic),
+    or None if the file can't be read. A file may contain both (e.g. a
+    post-quantum key appended next to a classic one to keep decrypting old
+    backups); age refuses to encrypt to such a mix, so callers treat that
+    case specially."""
     try:
         text = identity.read_text(errors="replace")
     except OSError:
@@ -1800,6 +1801,19 @@ def _identity_is_post_quantum(identity: Path) -> bool | None:
             has_pq = True
         elif stripped.startswith("AGE-SECRET-KEY-1"):
             has_classic = True
+    return has_pq, has_classic
+
+
+def _identity_is_post_quantum(identity: Path) -> bool | None:
+    """Classify an age identity file: True if it holds a post-quantum secret
+    key (AGE-SECRET-KEY-PQ-...), False if it holds a classic X25519 key
+    (AGE-SECRET-KEY-1...), or None if the type can't be determined (e.g. a
+    plugin identity, or the file can't be read). A file mixing both key types
+    classifies as True (a post-quantum key is present)."""
+    flags = _scan_identity_key_types(identity)
+    if flags is None:
+        return None
+    has_pq, has_classic = flags
     if has_pq:
         return True
     if has_classic:
@@ -1878,12 +1892,23 @@ def pre_flight_checks() -> None:
             log.warning(
                 f"age identity file {identity} has loose permissions ({mode:o}); consider: chmod 600 {identity}"
             )
-        if _identity_is_post_quantum(identity) is False:
-            log.warning(
-                f"age identity file {identity} is a classic X25519 key, so new "
-                f"backups will NOT be post-quantum. Regenerate with: "
-                f"age-keygen -pq -o {identity}"
-            )
+        key_types = _scan_identity_key_types(identity)
+        if key_types is not None:
+            has_pq, has_classic = key_types
+            if has_pq and has_classic:
+                log.warning(
+                    f"age identity file {identity} mixes post-quantum and classic "
+                    f"identities; age refuses to encrypt to both (incompatible "
+                    f"recipients), so new backups will FAIL. Remove the classic "
+                    f"AGE-SECRET-KEY-1... line (or regenerate with: "
+                    f"age-keygen -pq -o {identity})."
+                )
+            elif has_classic:
+                log.warning(
+                    f"age identity file {identity} is a classic X25519 key, so new "
+                    f"backups will NOT be post-quantum. Regenerate with: "
+                    f"age-keygen -pq -o {identity}"
+                )
 
     try:
         _ = pwd.getpwnam(config.backup_user)

--- a/server-scripts/backup/python/overengineered-backup-script.py
+++ b/server-scripts/backup/python/overengineered-backup-script.py
@@ -13,14 +13,15 @@
 # A robust, automated backup and off-site upload script using Python.
 #
 # Features:
-# - Creates local encrypted backups via a streaming tar -> pigz/gzip -> age
-#   pipeline (no temporary uncompressed archive on disk).
+# - Creates local backups encrypted with age (post-quantum hybrid X25519 +
+#   ML-KEM-768) via a streaming tar -> pigz/gzip -> age pipeline (no temporary
+#   uncompressed archive on disk).
 # - Manages Docker services, with priority restart for critical containers.
 # - Uploads backups to a cloud remote using rclone.
 # - Sends detailed status notifications to a Discord webhook.
 # - Optionally uploads full logs to PrivateBin for easy debugging.
 # - Robust error handling, log rotation, concurrency locking, and a
-#   built-in restore mode (supports legacy openssl-encrypted backups too).
+#   built-in restore mode.
 #
 # Usage:
 #   sudo ./overengineered-backup-script.py [--config /etc/backup-script.toml]
@@ -31,12 +32,13 @@
 #
 # Requirements:
 # - Python 3.14+ (run via `uv run`; dependencies resolve automatically)
-# - rclone, tar (GNU), pigz/gzip, age, docker
-# - openssl (only needed to restore legacy .enc backups)
+# - rclone, tar (GNU), pigz/gzip, age (>= 1.3.0 for post-quantum keys), docker
 # - (Optional) privatebin (from gearnode/privatebin)
 #
 # Encryption key setup (one time):
-#   age-keygen -o /root/.backup_age_key.txt && chmod 600 /root/.backup_age_key.txt
+#   age-keygen -pq -o /root/.backup_age_key.txt && chmod 600 /root/.backup_age_key.txt
+#   The -pq flag creates a post-quantum hybrid identity (age v1.3.0+); the
+#   backup pipeline encrypts to this identity's own recipient automatically.
 #   !! Copy the key somewhere safe OFF this machine - if the key is lost,
 #   !! every backup encrypted with it is permanently unreadable.
 # -----------------------------------------------------------------------------
@@ -201,7 +203,6 @@ class Config:
 
     # [encryption]
     age_identity_file: Path = Path("/root/.backup_age_key.txt")
-    legacy_password_file: Path = Path("/root/.backup_password")
 
     # [docker]
     docker_enabled: bool = True
@@ -272,7 +273,6 @@ _TOML_SCHEMA: dict[str, dict[str, str]] = {
     },
     "encryption": {
         "age_identity_file": "age_identity_file",
-        "legacy_password_file": "legacy_password_file",
     },
     "docker": {
         "enabled": "docker_enabled",
@@ -461,11 +461,10 @@ compression_level = {c.compression_level}
 
 [encryption]
 # age identity (private key) used to encrypt and decrypt backups.
-# Generate with: age-keygen -o {c.age_identity_file} && chmod 600 {c.age_identity_file}
+# Generate a post-quantum hybrid key (age v1.3.0+) with:
+#   age-keygen -pq -o {c.age_identity_file} && chmod 600 {c.age_identity_file}
 # KEEP A COPY OF THIS KEY OFF THIS MACHINE - lost key means unreadable backups.
 age_identity_file = "{c.age_identity_file}"
-# Password file for restoring legacy openssl-encrypted (.enc) backups.
-legacy_password_file = "{c.legacy_password_file}"
 
 [docker]
 enabled = {b(c.docker_enabled)}
@@ -1785,6 +1784,29 @@ def _report_backup_sources() -> None:
         log.info(f"  excluded  {excl}{'' if excl.exists() else ' (not present)'}")
 
 
+def _identity_is_post_quantum(identity: Path) -> bool | None:
+    """Classify an age identity file: True if it holds a post-quantum secret
+    key (AGE-SECRET-KEY-PQ-...), False if it holds a classic X25519 key
+    (AGE-SECRET-KEY-1...), or None if the type can't be determined (e.g. a
+    plugin identity, or the file can't be read)."""
+    try:
+        text = identity.read_text(errors="replace")
+    except OSError:
+        return None
+    has_pq = has_classic = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("AGE-SECRET-KEY-PQ-"):
+            has_pq = True
+        elif stripped.startswith("AGE-SECRET-KEY-1"):
+            has_classic = True
+    if has_pq:
+        return True
+    if has_classic:
+        return False
+    return None
+
+
 def pre_flight_checks() -> None:
     """Perform pre-flight checks before starting backup.
 
@@ -1848,13 +1870,19 @@ def pre_flight_checks() -> None:
     identity = config.age_identity_file
     if not identity.is_file() or identity.stat().st_size == 0:
         problem(
-            f"age identity file not found or empty: {identity}. Create it with: age-keygen -o {identity} && chmod 600 {identity} - and KEEP A COPY OFF THIS MACHINE (lost key = unreadable backups)."
+            f"age identity file not found or empty: {identity}. Create it with: age-keygen -pq -o {identity} && chmod 600 {identity} - and KEEP A COPY OFF THIS MACHINE (lost key = unreadable backups)."
         )
     else:
         mode = identity.stat().st_mode & 0o777
         if mode & 0o077:
             log.warning(
                 f"age identity file {identity} has loose permissions ({mode:o}); consider: chmod 600 {identity}"
+            )
+        if _identity_is_post_quantum(identity) is False:
+            log.warning(
+                f"age identity file {identity} is a classic X25519 key, so new "
+                f"backups will NOT be post-quantum. Regenerate with: "
+                f"age-keygen -pq -o {identity}"
             )
 
     try:
@@ -2633,44 +2661,18 @@ def send_final_status_notification(success: bool, log_file: Path | None) -> None
 # -----------------------------------------------------------------------------
 
 
-def _decrypt_stage(
-    backup_file: Path, identity: Path, password_file: Path
-) -> tuple[str, list[str]]:
-    """Build the first pipeline stage for restoring a backup, based on its
-    format: .age (current) or legacy openssl .enc."""
+def _decrypt_stage(backup_file: Path, identity: Path) -> tuple[str, list[str]]:
+    """Build the age-decrypt first stage of the restore pipeline."""
     name = backup_file.name
-    if name.endswith(".age"):
-        if not identity.is_file():
-            raise BackupError(
-                f"age identity file not found: {identity} (use --identity PATH)"
-            )
-        return (
-            "age",
-            [resolve_command("age"), "-d", "-i", str(identity)],
+    if not name.endswith(".age"):
+        raise BackupError(
+            f"Unsupported backup format: {name} (expected *.tar.gz.age)"
         )
-    if name.endswith(".enc"):
-        if not password_file.is_file():
-            raise BackupError(
-                f"Password file not found: {password_file} (use --password-file PATH)"
-            )
-        # Must match exactly how legacy backups were created (no -iter flag).
-        return (
-            "openssl",
-            [
-                resolve_command("openssl"),
-                "enc",
-                "-d",
-                "-aes-256-cbc",
-                "-md",
-                "sha256",
-                "-pass",
-                f"file:{password_file.resolve()}",
-                "-pbkdf2",
-            ],
+    if not identity.is_file():
+        raise BackupError(
+            f"age identity file not found: {identity} (use --identity PATH)"
         )
-    raise BackupError(
-        f"Unsupported backup format: {name} (expected *.tar.gz.age or *.tar.gz.enc)"
-    )
+    return ("age", [resolve_command("age"), "-d", "-i", str(identity)])
 
 
 def run_restore(
@@ -2679,7 +2681,6 @@ def run_restore(
     list_only: bool,
     force: bool,
     identity: Path,
-    password_file: Path,
 ) -> int:
     """List or extract a backup archive. Returns a process exit code."""
     if not backup_file.is_file():
@@ -2687,7 +2688,7 @@ def run_restore(
         return 1
 
     try:
-        decrypt = _decrypt_stage(backup_file, identity, password_file)
+        decrypt = _decrypt_stage(backup_file, identity)
     except BackupError as e:
         log.critical(str(e))
         return 1
@@ -2906,7 +2907,7 @@ def _run_backup(timestamp: str, log_file: Path | None) -> int:
         if backup_state.backup_verified:
             _ = rotate_items(
                 config.backup_root_dir,
-                ["*.tar.gz.age", "*.tar.gz.enc"],
+                "*.tar.gz.age",
                 config.retention_backups,
             )
             cleanup_orphan_manifests(config.backup_root_dir)
@@ -3022,7 +3023,6 @@ class CliArgs(argparse.Namespace):
     list_contents: bool = False
     force: bool = False
     identity: Path | None = None
-    password_file: Path | None = None
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -3095,13 +3095,6 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="PATH",
         help="age identity file (default: from config).",
-    )
-    _ = restore.add_argument(
-        "--password-file",
-        type=Path,
-        default=None,
-        metavar="PATH",
-        help="Password file for legacy .enc backups (default: from config).",
     )
     _ = restore.add_argument(
         "--verbose", action="store_true", help="Enable debug logging."
@@ -3188,7 +3181,6 @@ def cmd_restore(args: CliArgs) -> int:
         list_only=args.list_contents,
         force=args.force,
         identity=args.identity or config.age_identity_file,
-        password_file=args.password_file or config.legacy_password_file,
     )
 
 

--- a/server-scripts/backup/python/overengineered-backup-script.py
+++ b/server-scripts/backup/python/overengineered-backup-script.py
@@ -1870,7 +1870,7 @@ def pre_flight_checks() -> None:
     identity = config.age_identity_file
     if not identity.is_file() or identity.stat().st_size == 0:
         problem(
-            f"age identity file not found or empty: {identity}. Create it with: age-keygen -pq -o {identity} && chmod 600 {identity} - and KEEP A COPY OFF THIS MACHINE (lost key = unreadable backups)."
+            f"age identity file not found or empty: {identity}. Create it with: age-keygen -pq -o {identity} && chmod 600 {identity} (the -pq flag requires age >= 1.3.0) - and KEEP A COPY OFF THIS MACHINE (lost key = unreadable backups)."
         )
     else:
         mode = identity.stat().st_mode & 0o777
@@ -2664,7 +2664,7 @@ def send_final_status_notification(success: bool, log_file: Path | None) -> None
 def _decrypt_stage(backup_file: Path, identity: Path) -> tuple[str, list[str]]:
     """Build the age-decrypt first stage of the restore pipeline."""
     name = backup_file.name
-    if not name.endswith(".age"):
+    if not name.endswith(".tar.gz.age"):
         raise BackupError(
             f"Unsupported backup format: {name} (expected *.tar.gz.age)"
         )

--- a/server-scripts/backup/python/overengineered-backup-script.py
+++ b/server-scripts/backup/python/overengineered-backup-script.py
@@ -1893,10 +1893,17 @@ def pre_flight_checks() -> None:
                 f"age identity file {identity} has loose permissions ({mode:o}); consider: chmod 600 {identity}"
             )
         key_types = _scan_identity_key_types(identity)
-        if key_types is not None:
+        if key_types is None:
+            problem(
+                f"age identity file {identity} exists but could not be read "
+                f"(permission or I/O error); cannot verify its key type, and "
+                f"the backup run would later fail when age tries to use it. Fix "
+                f"ownership/permissions so root can read it (e.g. chmod 600 {identity})."
+            )
+        else:
             has_pq, has_classic = key_types
             if has_pq and has_classic:
-                log.warning(
+                problem(
                     f"age identity file {identity} mixes post-quantum and classic "
                     f"identities; age refuses to encrypt to both (incompatible "
                     f"recipients), so new backups will FAIL. Remove the classic "

--- a/server-scripts/backup/python/overengineered-backup-script.py
+++ b/server-scripts/backup/python/overengineered-backup-script.py
@@ -54,6 +54,7 @@ import json
 import logging
 import os
 import pwd
+import re
 import shutil
 import signal
 import subprocess
@@ -1821,6 +1822,25 @@ def _identity_is_post_quantum(identity: Path) -> bool | None:
     return None
 
 
+def _age_version_supports_pq(age_path: str) -> bool | None:
+    """Return True if `age --version` reports >= 1.3.0 (post-quantum capable),
+    False if it reports an older version, or None if the version can't be
+    determined (--version failed, or the output wasn't parseable). age >= 1.3.0
+    is required to encrypt/decrypt post-quantum (AGE-SECRET-KEY-PQ-) identities."""
+    try:
+        result = run_command([age_path, "--version"], timeout=10)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    # age prints e.g. "v1.3.1" on stdout; fall back to stderr if stdout is empty.
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", result.stdout or result.stderr)
+    if not match:
+        return None
+    version = tuple(int(part) for part in match.groups())
+    return version >= (1, 3, 0)
+
+
 def pre_flight_checks() -> None:
     """Perform pre-flight checks before starting backup.
 
@@ -1907,9 +1927,27 @@ def pre_flight_checks() -> None:
                     f"age identity file {identity} mixes post-quantum and classic "
                     f"identities; age refuses to encrypt to both (incompatible "
                     f"recipients), so new backups will FAIL. Remove the classic "
-                    f"AGE-SECRET-KEY-1... line (or regenerate with: "
-                    f"age-keygen -pq -o {identity})."
+                    f"AGE-SECRET-KEY-1... line - but keep a copy of that classic key "
+                    f"somewhere safe first, since you'll still need it to restore "
+                    f"older classic-encrypted backups - or regenerate with: "
+                    f"age-keygen -pq -o {identity}."
                 )
+            elif has_pq:
+                age_path = find_command("age")
+                supports = _age_version_supports_pq(age_path) if age_path else None
+                if supports is False:
+                    problem(
+                        f"age identity file {identity} is post-quantum, but the "
+                        f"installed age is older than 1.3.0 and cannot use it; the "
+                        f"backup would fail at the encryption stage. Upgrade age to "
+                        f">= 1.3.0."
+                    )
+                elif supports is None:
+                    log.warning(
+                        f"could not determine the installed age version; age >= 1.3.0 "
+                        f"is required to use the post-quantum identity {identity}. If "
+                        f"your age is older, backups will fail at encryption."
+                    )
             elif has_classic:
                 log.warning(
                     f"age identity file {identity} is a classic X25519 key, so new "

--- a/server-scripts/backup/python/test_backup_script.py
+++ b/server-scripts/backup/python/test_backup_script.py
@@ -172,6 +172,39 @@ class TestPreFlightDryRun(ScriptTestCase):
         self.assertTrue(mod.backup_state.errors)
         self.assertIn("Invalid docker shutdown_method", mod.backup_state.errors[0])
 
+    def test_mixed_identity_is_aggregated_not_raised(self):
+        # A post-quantum + classic mix makes age refuse to encrypt (incompatible
+        # recipients), so pre-flight must fail fast rather than warn-and-continue.
+        identity = self.tmp / "mixed.txt"
+        identity.write_text(
+            "AGE-SECRET-KEY-PQ-1EXAMPLEEXAMPLEEXAMPLE\n"
+            "AGE-SECRET-KEY-1EXAMPLEEXAMPLEEXAMPLE\n"
+        )
+        mod.config.age_identity_file = identity
+        mod.dry_run_mode = True
+        mod.pre_flight_checks()  # must not raise in dry-run mode
+        self.assertTrue(mod.backup_state.errors)
+        self.assertIn("mixes post-quantum and classic", mod.backup_state.errors[0])
+
+    def test_unreadable_identity_is_aggregated_not_raised(self):
+        # If the identity exists and is non-empty but can't be read (OSError ->
+        # _scan_identity_key_types returns None), pre-flight must fail fast
+        # instead of silently skipping the key-type check and only failing later
+        # in the age pipeline. Patch the scanner to force the None branch (the
+        # OSError -> None mapping itself is covered by
+        # TestIdentityClassification.test_unknown_when_unreadable), keeping this
+        # test deterministic whether or not it runs as root.
+        identity = self.tmp / "present-but-unreadable.txt"
+        identity.write_text("AGE-SECRET-KEY-PQ-1EXAMPLEEXAMPLEEXAMPLE\n")
+        original = mod._scan_identity_key_types
+        mod._scan_identity_key_types = lambda _identity: None
+        self.addCleanup(setattr, mod, "_scan_identity_key_types", original)
+        mod.config.age_identity_file = identity
+        mod.dry_run_mode = True
+        mod.pre_flight_checks()  # must not raise in dry-run mode
+        self.assertTrue(mod.backup_state.errors)
+        self.assertIn("could not be read", mod.backup_state.errors[0])
+
     def test_dry_run_problems_are_recorded_as_errors(self):
         # On any non-root test machine at least the root check fails, so the
         # dry run must record an error (=> non-zero exit) instead of only

--- a/server-scripts/backup/python/test_backup_script.py
+++ b/server-scripts/backup/python/test_backup_script.py
@@ -592,6 +592,17 @@ class TestIdentityClassification(ScriptTestCase):
     def test_unknown_when_unreadable(self):
         self.assertIsNone(mod._identity_is_post_quantum(self.tmp / "missing.txt"))
 
+    def test_detects_mixed_keys(self):
+        key = self.tmp / "mixed.txt"
+        key.write_text(
+            "AGE-SECRET-KEY-PQ-1EXAMPLEEXAMPLEEXAMPLE\n"
+            "AGE-SECRET-KEY-1EXAMPLEEXAMPLEEXAMPLE\n"
+        )
+        # A mixed file is flagged distinctly (age refuses to encrypt to both),
+        # while the ternary classifier still reports True (a PQ key is present).
+        self.assertEqual(mod._scan_identity_key_types(key), (True, True))
+        self.assertIs(mod._identity_is_post_quantum(key), True)
+
 
 @unittest.skipUnless(_age_supports_pq(), "age-keygen -pq (age >= 1.3.0) required")
 class TestPostQuantumRoundTrip(ScriptTestCase):

--- a/server-scripts/backup/python/test_backup_script.py
+++ b/server-scripts/backup/python/test_backup_script.py
@@ -298,6 +298,24 @@ backup_root_dir = "/custom/backups"
         with self.assertRaises(mod.ConfigError):
             mod.load_config(path)
 
+    def test_removed_legacy_password_file_gives_upgrade_hint(self):
+        # A stale config with the dropped [encryption] legacy_password_file key
+        # must fail with an actionable message, not the bare "unknown key" one.
+        path = self._write('[encryption]\nlegacy_password_file = "/root/.key"\n')
+        with self.assertRaises(mod.ConfigError) as ctx:
+            mod.load_config(path)
+        message = str(ctx.exception)
+        self.assertIn("legacy openssl", message)
+        self.assertIn("Delete it", message)
+
+    def test_unknown_encryption_key_still_generic(self):
+        # A genuinely-unknown key must keep the generic error - the removed-key
+        # special case must not swallow every unknown key in the section.
+        path = self._write('[encryption]\nbogus_key = "x"\n')
+        with self.assertRaises(mod.ConfigError) as ctx:
+            mod.load_config(path)
+        self.assertIn("unknown key", str(ctx.exception))
+
     def test_wrong_type_rejected(self):
         path = self._write('[retention]\nbackups = "three"\n')
         with self.assertRaises(mod.ConfigError):

--- a/server-scripts/backup/python/test_backup_script.py
+++ b/server-scripts/backup/python/test_backup_script.py
@@ -637,7 +637,62 @@ class TestIdentityClassification(ScriptTestCase):
         self.assertIs(mod._identity_is_post_quantum(key), True)
 
 
-@unittest.skipUnless(_age_supports_pq(), "age-keygen -pq (age >= 1.3.0) required")
+class TestAgeVersionSupportsPq(ScriptTestCase):
+    """_age_version_supports_pq gates the post-quantum pre-flight check: True
+    for age >= 1.3.0, False for older, None when the version is undeterminable
+    (so pre-flight fails open rather than blocking an oddly-versioned age).
+    Stubs run_command so no real age binary is needed."""
+
+    def _stub_version(self, *, stdout="", stderr="", returncode=0):
+        result = subprocess.CompletedProcess(
+            ["age", "--version"], returncode, stdout, stderr
+        )
+        original = mod.run_command
+        mod.run_command = lambda *_a, **_k: result
+        self.addCleanup(setattr, mod, "run_command", original)
+
+    def test_newer_patch_supported(self):
+        self._stub_version(stdout="v1.3.1\n")
+        self.assertIs(mod._age_version_supports_pq("age"), True)
+
+    def test_exact_threshold_supported(self):
+        self._stub_version(stdout="v1.3.0\n")
+        self.assertIs(mod._age_version_supports_pq("age"), True)
+
+    def test_older_minor_unsupported(self):
+        self._stub_version(stdout="v1.2.9\n")
+        self.assertIs(mod._age_version_supports_pq("age"), False)
+
+    def test_much_older_unsupported(self):
+        self._stub_version(stdout="v1.2.0\n")
+        self.assertIs(mod._age_version_supports_pq("age"), False)
+
+    def test_unparseable_version_is_none(self):
+        self._stub_version(stdout="(devel)\n")
+        self.assertIsNone(mod._age_version_supports_pq("age"))
+
+    def test_nonzero_returncode_is_none(self):
+        self._stub_version(stdout="v1.3.1\n", returncode=1)
+        self.assertIsNone(mod._age_version_supports_pq("age"))
+
+    def test_version_read_from_stderr_when_stdout_empty(self):
+        self._stub_version(stdout="", stderr="v1.3.1\n")
+        self.assertIs(mod._age_version_supports_pq("age"), True)
+
+    def test_command_error_is_none(self):
+        original = mod.run_command
+
+        def boom(*_a: object, **_k: object) -> object:
+            raise OSError("age missing")
+
+        mod.run_command = boom
+        self.addCleanup(setattr, mod, "run_command", original)
+        self.assertIsNone(mod._age_version_supports_pq("age"))
+
+
+@unittest.skipUnless(
+    _age_supports_pq() and AGE, "age + age-keygen -pq (age >= 1.3.0) required"
+)
 class TestPostQuantumRoundTrip(ScriptTestCase):
     """Confirm the encrypt/verify/restore round-trip works with a post-quantum
     (-pq) age identity - the recipient type the backup pipeline relies on."""

--- a/server-scripts/backup/python/test_backup_script.py
+++ b/server-scripts/backup/python/test_backup_script.py
@@ -40,6 +40,17 @@ def _tar_is_gnu() -> bool:
     return mod.tar_is_gnu(mod.resolve_tar())
 
 
+def _age_supports_pq() -> bool:
+    """True if the installed age-keygen can mint post-quantum (-pq) keys."""
+    if not AGE_KEYGEN:
+        return False
+    try:
+        result = subprocess.run([AGE_KEYGEN, "-pq"], capture_output=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and b"AGE-SECRET-KEY-PQ-" in result.stdout
+
+
 def setUpModule() -> None:
     logging.disable(logging.CRITICAL)
 
@@ -310,13 +321,15 @@ class TestRotation(ScriptTestCase):
         self.assertEqual(remaining, sorted(p.name for p in files[3:]))
 
     def test_multiple_patterns_rotate_together(self):
-        old = self._make_files(["old1_backup.tar.gz.enc", "old2_backup.tar.gz.enc"])
-        new = self._make_files(["new1_backup.tar.gz.age", "new2_backup.tar.gz.age"])
+        # rotate_items accepts a list of globs and rotates their union as one
+        # pool, keeping the newest retention_count across all patterns.
+        old = self._make_files(["old1_backup.tar.gz.age", "old2.log"])
+        new = self._make_files(["new1_backup.tar.gz.age", "new2.log"])
         # old files were created first but _make_files re-bases mtimes per
-        # call; force the .enc files to be oldest explicitly.
+        # call; force the old files to be oldest explicitly.
         for p in old:
             os.utime(p, (time.time() - 10_000, time.time() - 10_000))
-        removed = mod.rotate_items(self.tmp, ["*.tar.gz.age", "*.tar.gz.enc"], 2)
+        removed = mod.rotate_items(self.tmp, ["*.tar.gz.age", "*.log"], 2)
         self.assertEqual(sorted(p.name for p in removed), sorted(p.name for p in old))
         self.assertTrue(all(p.exists() for p in new))
 
@@ -465,9 +478,7 @@ class TestRestoreRoundTrip(ScriptTestCase):
             output_dir=None,
             list_only=True,
             force=False,
-            identity=self.identity,
-            password_file=self.tmp / "unused",
-        )
+            identity=self.identity,        )
         self.assertEqual(rc, 0)
 
     def test_restore_extract_and_compare(self):
@@ -477,9 +488,7 @@ class TestRestoreRoundTrip(ScriptTestCase):
             output_dir=out,
             list_only=False,
             force=False,
-            identity=self.identity,
-            password_file=self.tmp / "unused",
-        )
+            identity=self.identity,        )
         self.assertEqual(rc, 0)
         self.assertEqual((out / "src" / "hello.txt").read_text(), "hello world\n")
         self.assertEqual(
@@ -495,9 +504,7 @@ class TestRestoreRoundTrip(ScriptTestCase):
             output_dir=out,
             list_only=False,
             force=False,
-            identity=self.identity,
-            password_file=self.tmp / "unused",
-        )
+            identity=self.identity,        )
         self.assertEqual(rc, 1)
         self.assertEqual((out / "existing.txt").read_text(), "do not clobber")
 
@@ -509,9 +516,7 @@ class TestRestoreRoundTrip(ScriptTestCase):
             output_dir=None,
             list_only=True,
             force=False,
-            identity=self.identity,
-            password_file=self.tmp / "unused",
-        )
+            identity=self.identity,        )
         self.assertEqual(rc, 1)
 
 
@@ -556,13 +561,93 @@ class TestCreateBackupEndToEnd(ScriptTestCase):
             output_dir=out,
             list_only=False,
             force=False,
-            identity=identity,
-            password_file=self.tmp / "unused",
-        )
+            identity=identity,        )
         self.assertEqual(rc, 0)
         restored_root = out / str(src.resolve()).lstrip("/")
         self.assertEqual((restored_root / "a.txt").read_text(), "alpha")
         self.assertFalse((restored_root / "excluded").exists())
+
+
+class TestIdentityClassification(ScriptTestCase):
+    """_identity_is_post_quantum classifies an age identity by key prefix."""
+
+    def test_detects_post_quantum_key(self):
+        key = self.tmp / "pq.txt"
+        key.write_text(
+            "# created: 2025-01-01T00:00:00Z\n"
+            "# public key: age1pq1abc\n"
+            "AGE-SECRET-KEY-PQ-1EXAMPLEEXAMPLEEXAMPLE\n"
+        )
+        self.assertIs(mod._identity_is_post_quantum(key), True)
+
+    def test_detects_classic_key(self):
+        key = self.tmp / "classic.txt"
+        key.write_text(
+            "# created: 2025-01-01T00:00:00Z\n"
+            "# public key: age1abc\n"
+            "AGE-SECRET-KEY-1EXAMPLEEXAMPLEEXAMPLE\n"
+        )
+        self.assertIs(mod._identity_is_post_quantum(key), False)
+
+    def test_unknown_when_unreadable(self):
+        self.assertIsNone(mod._identity_is_post_quantum(self.tmp / "missing.txt"))
+
+
+@unittest.skipUnless(_age_supports_pq(), "age-keygen -pq (age >= 1.3.0) required")
+class TestPostQuantumRoundTrip(ScriptTestCase):
+    """Confirm the encrypt/verify/restore round-trip works with a post-quantum
+    (-pq) age identity - the recipient type the backup pipeline relies on."""
+
+    def test_pq_verify_and_restore(self):
+        identity = self.tmp / "pqkey.txt"
+        subprocess.run(
+            [AGE_KEYGEN, "-pq", "-o", str(identity)],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+        identity.chmod(0o600)
+        # Sanity: the generated key really is post-quantum.
+        self.assertIs(mod._identity_is_post_quantum(identity), True)
+
+        src = self.tmp / "src"
+        (src / "sub").mkdir(parents=True)
+        (src / "hello.txt").write_text("pq hello\n")
+
+        # Build fixture archive: tar | gzip | age (no GNU-only flags).
+        backup_file = self.tmp / "pq_backup.tar.gz.age"
+        tar = subprocess.Popen(
+            [mod.resolve_tar(), "-cf", "-", "-C", str(self.tmp), "src"],
+            stdout=subprocess.PIPE,
+        )
+        gz = subprocess.Popen(
+            ["gzip", "-3"], stdin=tar.stdout, stdout=subprocess.PIPE
+        )
+        age = subprocess.Popen(
+            [AGE, "-e", "-i", str(identity), "-o", str(backup_file)],
+            stdin=gz.stdout,
+        )
+        tar.stdout.close()
+        gz.stdout.close()
+        self.assertEqual(age.wait(timeout=60), 0)
+        self.assertEqual(gz.wait(timeout=10), 0)
+        self.assertEqual(tar.wait(timeout=10), 0)
+
+        mod.config.age_identity_file = identity
+        mod.config.compression_tool = "gzip"
+
+        self.assertTrue(mod.verify_backup(backup_file))
+
+        out = self.tmp / "restored"
+        rc = mod.run_restore(
+            backup_file=backup_file,
+            output_dir=out,
+            list_only=False,
+            force=False,
+            identity=identity,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual((out / "src" / "hello.txt").read_text(), "pq hello\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to #7. This applies two requested changes to the Python backup script (`server-scripts/backup/python/overengineered-backup-script.py`):

1. **Use age's post-quantum (`-pq`) keys** for backup encryption.
2. **Drop legacy backwards compatibility** for openssl `.enc` restore (manual openssl restore remains possible if ever needed).

## 1. Post-quantum encryption

age v1.3.0+ provides native post-quantum hybrid recipients (X25519 + ML-KEM-768). Post-quantum protection is selected by the **identity/recipient type**, not by a flag on the `age` encrypt command, so the streaming backup pipeline (`age -e -i <identity>`, which encrypts to the identity's own recipient) is intentionally left unchanged. A post-quantum identity is created with `age-keygen -pq`.

Changes:
- Key-generation guidance now uses `age-keygen -pq` in the header comment, the emitted config template (`--print-default-config`), and the pre-flight error message.
- New pre-flight warning: if the configured identity is a classic X25519 key, the run logs a warning (in both normal and `--dry-run` mode) so a non-post-quantum key cannot silently downgrade new backups. The warning only fires when the key is *definitively* classic; plugin / passphrase / unknown identities are left alone.
- New helper `_identity_is_post_quantum()` classifies an identity as post-quantum (`AGE-SECRET-KEY-PQ-`), classic (`AGE-SECRET-KEY-1`), or unknown.

To adopt post-quantum backups, generate a new identity:

```
age-keygen -pq -o /root/.backup_age_key.txt && chmod 600 /root/.backup_age_key.txt
```

Keep the old key off-machine if you still need to decrypt older backups made with it.

## 2. Remove legacy openssl `.enc` restore support

The `restore` subcommand no longer decrypts legacy openssl-encrypted archives. Removed:
- The openssl decrypt branch in `_decrypt_stage` (now age-only; `_decrypt_stage(backup_file, identity)`).
- The `[encryption] legacy_password_file` config field and its TOML schema mapping.
- The `restore --password-file` CLI argument and the `password_file` parameters it fed.
- `*.tar.gz.enc` from the backup rotation glob (rotation now manages `*.tar.gz.age` only).

Existing `.enc` archives can still be decrypted manually:

```
openssl enc -aes-256-cbc -md sha256 -d -pbkdf2 -pass file:<password-file> -in backup.tar.gz.enc | gzip -d | tar -xf -
```

> Note for upgraders: because `*.tar.gz.enc` is no longer in the rotation glob, any legacy `.enc` archives already on disk (local and mirrored remote) are no longer auto-rotated and will remain until manually removed. This is the safe direction — the script will not auto-delete backups it can no longer restore.

## Tests

`python server-scripts/backup/python/test_backup_script.py` — 49 tests pass.

- Added `TestPostQuantumRoundTrip`: a real create/verify/restore round-trip using an `age-keygen -pq` identity, with a sanity assertion that the generated key is post-quantum. Guarded by `skipUnless` so it skips on age installs without `-pq`.
- Added `TestIdentityClassification` unit tests for the new helper (post-quantum / classic / unreadable).
- Removed the `password_file` argument from all `run_restore` test calls.
- Rewrote the multi-pattern rotation test to drop the legacy `.enc` fixture while still covering the `rotate_items` list-of-globs path (now via `*.log`).
- `test_restore_rejects_unknown_format` continues to assert unsupported formats are rejected.

## Compatibility

- Requires `age >= 1.3.0` to generate post-quantum keys (the resolver still uses the existing Homebrew/Linuxbrew PATH fallback). Classic keys keep working, but new backups made with them are flagged by the pre-flight warning.

## Breaking change

The `restore` subcommand no longer decrypts legacy openssl `.enc` backups; the `[encryption] legacy_password_file` config key and the `restore --password-file` flag have been removed.
